### PR TITLE
Use keyword arguments in Rails 5

### DIFF
--- a/lib/rspec/default_http_header.rb
+++ b/lib/rspec/default_http_header.rb
@@ -10,8 +10,18 @@ module RSpec
       let(:default_headers) { {} }
 
       HTTP_METHODS.each do |m|
-        define_method(m) do |path, parameters = nil, headers_or_env = {}|
-          super(path, parameters, default_headers.merge(headers_or_env))
+        if ActionDispatch::Integration::Session.private_method_defined?(:process_with_kwargs)
+          define_method(m) do |path, *args|
+            if args[0].respond_to?(:has_key?) && args[0].has_key?(:headers)
+              args[0][:headers].merge!(default_headers)
+            end
+
+            super(path, *args)
+          end
+        else
+          define_method(m) do |path, parameters = nil, headers_or_env = {}|
+            super(path, parameters, default_headers.merge(headers_or_env))
+          end
         end
       end
     end

--- a/lib/rspec/default_http_header.rb
+++ b/lib/rspec/default_http_header.rb
@@ -10,7 +10,7 @@ module RSpec
       let(:default_headers) { {} }
 
       HTTP_METHODS.each do |m|
-        if ActionDispatch::Integration::Session.private_method_defined?(:process_with_kwargs)
+        if ActionPack::VERSION::MAJOR >= 5
           define_method(m) do |path, *args|
             if args[0].respond_to?(:has_key?) && args[0].has_key?(:headers)
               args[0][:headers].merge!(default_headers)


### PR DESCRIPTION
Hi @kenchan kunsan.

In Rails 5, HTTP request methods issue the following deprecation warnings:

```
ActionDispatch::IntegrationTest HTTP request methods will accept only
the following keyword arguments in future Rails versions:
params, headers, env, xhr, as

Examples:

get '/profile',
  params: { id: 1 },
  headers: { 'X-Extra-Header' => '123' },
  env: { 'action_dispatch.custom' => 'custom' },
  xhr: true,
  as: :json
```

I added a patch to avoid this.

ref commit: https://github.com/rails/rails/commit/baf14ae513337cb185acf865e93dfc48f3aabf6a
ActionDispatch::IntegrationTest: https://github.com/rails/rails/blob/baf14ae513337cb185acf865e93dfc48f3aabf6a/actionpack/lib/action_dispatch/testing/integration.rb#L300-L307
