### PR TITLE
fixed rspec-rails v4.0.0.beta2

### DIFF
--- a/rspec-default_http_header.gemspec
+++ b/rspec-default_http_header.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rspec-rails", "~> 3.0"
+  spec.add_dependency "rspec-rails", "> 3.0"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
I want to use rspec-rails v4.0.0.beta2 with rspec-default_http_header